### PR TITLE
Go back to wallet selection

### DIFF
--- a/app/actions/ClientActions/index.js
+++ b/app/actions/ClientActions/index.js
@@ -267,10 +267,11 @@ export const getPingAttempt = () => (dispatch, getState) =>
     })
     .catch(error => {
       const {
-        daemon: { shutdownRequested }
+        daemon: { shutdownRequested, goBack }
       } = getState();
+
       dispatch({ error, type: T.GETPING_FAILED });
-      if (!shutdownRequested) {
+      if (!(shutdownRequested || goBack)) {
         pause(1000).then(() => {
           dispatch(pushHistory("/walletError"));
         });

--- a/app/actions/DaemonActions.js
+++ b/app/actions/DaemonActions.js
@@ -15,6 +15,7 @@ import { isTestNet } from "selectors";
 import axios from "axios";
 import { semverCompatible } from "./VersionActions";
 import { eq } from "fp";
+import { pause } from "helpers";
 
 export const EXILIBRIUM_VERSION = "EXILIBRIUM_VERSION";
 export const SELECT_LANGUAGE = "SELECT_LANGUAGE";
@@ -247,6 +248,20 @@ export const startWallet = selectedWallet => (dispatch, getState) => {
       console.log(err);
       dispatch({ type: DAEMONSTARTED_ERROR });
     });
+};
+
+export const QUIT_WALLET = "QUIT_WALLET";
+
+export const stopWallet = () => async dispatch => {
+  try {
+    dispatch(stopNotifcations());
+    await pause(100);
+    dispatch({ type: QUIT_WALLET });
+    await wallet.stopWallet();
+    dispatch(pushHistory("/getStarted"));
+  } catch (e) {
+    throw new Error(e);
+  }
 };
 
 export const prepStartDaemon = () => (dispatch, getState) => {

--- a/app/actions/WalletLoaderActions.js
+++ b/app/actions/WalletLoaderActions.js
@@ -319,7 +319,7 @@ const subscribeBlockAttempt = () => (dispatch, getState) => {
     .catch(error => dispatch({ error, type: SUBSCRIBEBLOCKNTFNS_FAILED }));
 };
 
-export const FETCHHEADERS_ATTEMPT = "FETCHHEADER_ATTEMPT";
+export const FETCHHEADERS_ATTEMPT = "FETCHHEADERS_ATTEMPT";
 export const FETCHHEADERS_FAILED = "FETCHHEADERS_FAILED";
 export const FETCHHEADERS_SUCCESS = "FETCHHEADERS_SUCCESS";
 export const FETCHHEADERS_PROGRESS = "FETCHHEADERS_PROGRESS";

--- a/app/components/SideBar/index.js
+++ b/app/components/SideBar/index.js
@@ -72,7 +72,8 @@ class SideBar extends React.Component {
           showingSidebarMenu: this.props.showingSidebarMenu,
           expandSideBar: this.props.expandSideBar,
           onExpandSideBar: this.props.onExpandSideBar,
-          onReduceSideBar: this.props.onReduceSideBar
+          onReduceSideBar: this.props.onReduceSideBar,
+          stopWallet: this.props.stopWallet
         }}
       />
     );

--- a/app/components/buttons/RescanButton.js
+++ b/app/components/buttons/RescanButton.js
@@ -12,7 +12,7 @@ export default ({ rescanRequest, rescanAttempt }) => (
   <Tooltip text={<T id="sidebar.rescanBtn.tip" m={rescanBtnMessage} />} disabled={rescanRequest}>
     <button
       disabled={Boolean(rescanRequest)}
-      className={`rescan-button${rescanRequest ? " spin" : ""}`}
+      className={`rescan-button ${rescanRequest ? "spin" : ""}`}
       onClick={() => rescanAttempt(0)}
     />
   </Tooltip>

--- a/app/components/indicators/RescanProgress.js
+++ b/app/components/indicators/RescanProgress.js
@@ -18,7 +18,7 @@ const RescanProgress = ({
         min={0}
         max={1}
         value={rescanCurrentBlock / rescanEndBlock}
-        color="#2ed8a3"
+        color="#ff00a5"
       />
     </div>
     <div className="rescan-button-area">

--- a/app/components/shared/Balance.js
+++ b/app/components/shared/Balance.js
@@ -64,7 +64,7 @@ export const Balance = ({
 };
 
 Balance.propTypes = {
-  currencyDisplay: PropTypes.string.isRequired,
+  currencyDisplay: PropTypes.string,
   amount: PropTypes.any,
   onClick: PropTypes.func,
   bold: PropTypes.bool,
@@ -75,6 +75,10 @@ Balance.propTypes = {
   classNameWrapper: PropTypes.any,
   classNameUnit: PropTypes.any,
   preScaled: PropTypes.any
+};
+
+Balance.defaultProps = {
+  currencyDisplay: "EXCC"
 };
 
 export default balance(Balance);

--- a/app/connectors/walletContainer.js
+++ b/app/connectors/walletContainer.js
@@ -1,9 +1,24 @@
+import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { selectorMap } from "../fp";
 import * as selectors from "../selectors";
+import { stopWallet } from "../actions/DaemonActions";
 
 const mapStateToProps = selectorMap({
-  expandSideBar: selectors.expandSideBar
+  expandSideBar: selectors.expandSideBar,
+  walletName: selectors.getWalletName,
+  hasUnresolvedRequests: selectors.hasUnresolvedRequests
 });
 
-export default connect(mapStateToProps);
+const mapDispatchToProps = dispatch =>
+  bindActionCreators(
+    {
+      stopWallet
+    },
+    dispatch
+  );
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+);

--- a/app/containers/Wallet.js
+++ b/app/containers/Wallet.js
@@ -14,6 +14,8 @@ import TicketsPage from "components/views/TicketsPage";
 import SideBar from "components/SideBar";
 import { BlurableContainer } from "layout";
 import { walletContainer } from "connectors";
+import { Tooltip } from "shared";
+import { FormattedMessage as T } from "react-intl";
 
 const pageAnimation = {
   atEnter: { opacity: 0 },
@@ -24,7 +26,7 @@ const pageAnimation = {
 @autobind
 class Wallet extends React.Component {
   render() {
-    const { expandSideBar } = this.props;
+    const { expandSideBar, stopWallet, walletName, hasUnresolvedRequests } = this.props;
     return (
       <BlurableContainer className="page-body">
         <SideBar />
@@ -43,6 +45,21 @@ class Wallet extends React.Component {
           <Route path="/transactions" component={TransactionsPage} />
           <Route path="/tickets" component={TicketsPage} />
         </AnimatedSwitch>
+        <Tooltip
+          text={
+            hasUnresolvedRequests ? (
+              <T id="quitBtn.warning" m="Cannot quit with ongoing requests" />
+            ) : (
+              <T id="quitBtn.tip" m="Go back to wallet selection" />
+            )
+          }>
+          <button
+            className="quit-wallet-button"
+            onClick={stopWallet}
+            disabled={hasUnresolvedRequests}>
+            <span>{walletName}</span>
+          </button>
+        </Tooltip>
       </BlurableContainer>
     );
   }

--- a/app/index.js
+++ b/app/index.js
@@ -65,6 +65,7 @@ const initialState = {
     credentials: null,
     appData: null,
     shutdownRequested: false,
+    goBack: false,
     openForm: globalCfg.get("must_open_form"),
     remoteAppdataError: false,
     previousWallet: null,

--- a/app/reducers/control.js
+++ b/app/reducers/control.js
@@ -69,7 +69,7 @@ import {
   MODAL_SHOWN,
   MODAL_HIDDEN
 } from "../actions/ControlActions";
-import { WALLET_AUTOBUYER_SETTINGS } from "actions/DaemonActions";
+import { WALLET_AUTOBUYER_SETTINGS, QUIT_WALLET } from "actions/DaemonActions";
 
 import { EXPORT_STARTED, EXPORT_COMPLETED, EXPORT_ERROR } from "actions/StatisticsActions";
 
@@ -501,6 +501,26 @@ export default function control(state = {}, action) {
         maxPriceAbsolute: action.maxPriceAbsolute,
         maxPriceRelative: action.maxPriceRelative,
         maxPerBlock: action.maxPerBlock
+      };
+    case QUIT_WALLET:
+      return {
+        ...state,
+        balanceToMaintain: null,
+        maxFee: null,
+        maxPriceAbsolute: null,
+        maxPriceRelative: null,
+        maxPerBlock: null,
+        getTicketBuyerConfigError: null,
+        getTicketBuyerConfigRequestAttempt: false,
+        stopAutoBuyerError: null,
+        stopAutoBuyerRequestAttempt: false,
+        getTicketBuyerConfigResponse: null,
+        loadActiveDataFiltersError: null,
+        loadActiveDataFiltersRequestAttempt: false,
+        loadActiveDataFiltersResponse: null,
+        getNextAddressError: null,
+        getNextAddressRequestAttempt: false,
+        getNextAddressResponse: null
       };
     case EXPORT_STARTED:
       return {

--- a/app/reducers/daemon.js
+++ b/app/reducers/daemon.js
@@ -16,7 +16,8 @@ import {
   AVAILABLE_WALLETS,
   EXILIBRIUM_VERSION,
   FATAL_DAEMON_ERROR,
-  FATAL_WALLET_ERROR
+  FATAL_WALLET_ERROR,
+  QUIT_WALLET
 } from "../actions/DaemonActions";
 import { CREATEWALLET_GOBACK } from "../actions/WalletLoaderActions";
 import { UPDATEHIDDENACCOUNTS } from "../actions/ClientActions";
@@ -140,6 +141,12 @@ export default function version(state = {}, action) {
       return {
         ...state,
         walletError: action.error
+      };
+    case QUIT_WALLET:
+      return {
+        ...state,
+        goBack: true,
+        walletReady: false
       };
     default:
       return state;

--- a/app/reducers/grpc.js
+++ b/app/reducers/grpc.js
@@ -58,7 +58,7 @@ import {
   SETVOTECHOICES_SUCCESS,
   MATURINGHEIGHTS_CHANGED
 } from "../actions/ClientActions";
-import { STARTUPBLOCK, WALLETREADY } from "../actions/DaemonActions";
+import { STARTUPBLOCK, WALLETREADY, QUIT_WALLET } from "../actions/DaemonActions";
 import { NEWBLOCKCONNECTED } from "../actions/NotificationActions";
 import {
   GETDECODEMESSAGESERVICE_ATTEMPT,
@@ -535,6 +535,62 @@ export default function grpc(state = {}, action) {
       return {
         ...state,
         port: action.port
+      };
+    case QUIT_WALLET:
+      return {
+        ...state,
+        port: "9121",
+        getWalletServiceError: null,
+        getWalletServiceRequestAttempt: false,
+        walletService: null,
+        getTicketBuyerServiceError: null,
+        getTicketBuyerServiceRequestAttempt: false,
+        ticketBuyerService: null,
+        getVotingServiceError: null,
+        getVotingServiceRequestAttempt: false,
+        votingService: null,
+        getAgendaServiceError: null,
+        getAgendaServiceRequestAttempt: false,
+        agendaService: null,
+        getAgendasError: null,
+        getAgendasRequestAttempt: false,
+        getAgendasResponse: null,
+        getTicketPriceError: "",
+        getTicketPriceRequestAttempt: false,
+        getTicketPriceResponse: null,
+        getNetworkError: null,
+        getNetworkRequestAttempt: false,
+        getNetworkResponse: null,
+        getMessageDecodeServiceRequestAttempt: false,
+        getMessageDecodeServiceError: null,
+        getStakeInfoError: "",
+        getStakeInfoRequestAttempt: false,
+        getTicketsRequestAttempt: false,
+        decodeMessageService: null,
+        getStakeInfoResponse: null,
+        getAccountsError: "",
+        getAccountsRequestAttempt: false,
+        getAccountsResponse: null,
+        transactionsFilter: {
+          search: null, // The freeform text in the Search box
+          listDirection: "desc", // asc = oldest -> newest, desc => newest -> oldest
+          types: [], // desired transaction types (code). All if blank.
+          direction: null // direction of desired transactions (sent/received/transfer)
+        },
+        minedTransactions: [],
+        unminedTransactions: [],
+        transactions: [],
+        lastTransaction: null,
+        noMoreTransactions: false,
+        getTransactionsRequestAttempt: false,
+        getBalanceError: "",
+        getBalanceRequestAttempt: false,
+        balances: [],
+        getTransactionsRequestError: "",
+        recentRegularTransactions: [],
+        recentStakeTransactions: [],
+        tickets: [],
+        getTicketsRequestError: ""
       };
     default:
       return state;

--- a/app/reducers/notifications.js
+++ b/app/reducers/notifications.js
@@ -7,6 +7,7 @@ import {
   ACCOUNTNTFNS_END,
   CLEARUNMINEDMESSAGE
 } from "../actions/NotificationActions";
+import { QUIT_WALLET } from "actions/DaemonActions";
 
 export default function notifications(state = {}, action) {
   switch (action.type) {
@@ -47,6 +48,15 @@ export default function notifications(state = {}, action) {
       return {
         ...state,
         newUnminedMessage: null
+      };
+    case QUIT_WALLET:
+      return {
+        ...state,
+        transactionNtfns: null,
+        transactionNtfnsError: null,
+        accountNtfns: null,
+        decodedTransactions: {},
+        maturingBlockHeights: {}
       };
     default:
       return state;

--- a/app/reducers/settings.js
+++ b/app/reducers/settings.js
@@ -5,7 +5,8 @@ import {
   TOGGLE_MINING,
   SYSTEM_INFO_REQUEST_SUCCESS
 } from "../actions/SettingsActions";
-import { WALLET_SETTINGS, SELECT_LANGUAGE } from "actions/DaemonActions";
+import { WALLET_SETTINGS, SELECT_LANGUAGE, QUIT_WALLET } from "actions/DaemonActions";
+import { getGlobalCfg } from "config";
 
 export default function settings(state = {}, action) {
   switch (action.type) {
@@ -53,6 +54,19 @@ export default function settings(state = {}, action) {
           currencyDisplay: action.currencyDisplay,
           gapLimit: action.gapLimit
         }
+      };
+    case QUIT_WALLET: // eslint-disable-line no-case-declarations
+      const globalCfg = getGlobalCfg();
+      return {
+        currentSettings: {
+          locale: globalCfg.get("locale"),
+          daemonStartAdvanced: globalCfg.get("daemon_start_advanced")
+        },
+        tempSettings: {
+          locale: globalCfg.get("locale"),
+          daemonStartAdvanced: globalCfg.get("daemon_start_advanced")
+        },
+        settingsChanged: false
       };
     case TOGGLE_MINING:
       return {

--- a/app/reducers/sidebar.js
+++ b/app/reducers/sidebar.js
@@ -6,6 +6,7 @@ import {
   EXPAND_SIDE_MENU,
   REDUCE_SIDE_MENU
 } from "../actions/SidebarActions";
+import { QUIT_WALLET } from "actions/DaemonActions";
 
 export default function sidebar(state = {}, action) {
   switch (action.type) {
@@ -38,6 +39,13 @@ export default function sidebar(state = {}, action) {
       return {
         ...state,
         showingSidebarMenu: true
+      };
+    case QUIT_WALLET:
+      return {
+        ...state,
+        showingSidebar: true,
+        showingSidebarMenu: false,
+        expandSideBar: true
       };
     default:
       return state;

--- a/app/reducers/stakepool.js
+++ b/app/reducers/stakepool.js
@@ -7,7 +7,7 @@ import {
   REMOVESTAKEPOOLCONFIG
 } from "../actions/StakePoolActions";
 import { CLEARSTAKEPOOLCONFIG } from "../actions/WalletLoaderActions";
-import { WALLET_STAKEPOOL_SETTINGS } from "actions/DaemonActions";
+import { WALLET_STAKEPOOL_SETTINGS, QUIT_WALLET } from "actions/DaemonActions";
 
 export default function stakepool(state = {}, action) {
   switch (action.type) {
@@ -58,6 +58,13 @@ export default function stakepool(state = {}, action) {
         activeStakePoolConfig: action.activeStakePoolConfig,
         selectedStakePool: action.selectedStakePool,
         currentStakePoolConfig: action.currentStakePoolConfig
+      };
+    case QUIT_WALLET:
+      return {
+        ...state,
+        currentStakePoolConfig: null,
+        activeStakePoolConfig: false,
+        selectedStakePool: null
       };
     default:
       return state;

--- a/app/reducers/statistics.js
+++ b/app/reducers/statistics.js
@@ -6,7 +6,7 @@ import {
   GETMYTICKETSSTATS_SUCCESS,
   GETMYTICKETSSTATS_FAILED
 } from "actions/StatisticsActions";
-
+import { QUIT_WALLET } from "actions/DaemonActions";
 export default function statistics(state = {}, action) {
   switch (action.type) {
     case GETSTARTUPSTATS_ATTEMPT:
@@ -40,6 +40,12 @@ export default function statistics(state = {}, action) {
       return {
         ...state,
         getMyTicketsStatsRequest: false
+      };
+    case QUIT_WALLET:
+      return {
+        ...state,
+        loadingStartupStats: false,
+        dailyBalances: []
       };
     default:
       return state;

--- a/app/reducers/version.js
+++ b/app/reducers/version.js
@@ -7,6 +7,7 @@ import {
   WALLETRPCVERSION_SUCCESS,
   VERSION_NOT_VALID
 } from "../actions/VersionActions";
+import { QUIT_WALLET } from "actions/DaemonActions";
 
 export default function version(state = {}, action) {
   switch (action.type) {
@@ -28,6 +29,12 @@ export default function version(state = {}, action) {
         getWalletRPCVersionError: null,
         getVersionServiceRequestAttempt: false,
         versionService: action.versionService
+      };
+    case QUIT_WALLET:
+      return {
+        ...state,
+        versionService: null,
+        getWalletRPCVersionResponse: null
       };
     case WALLETRPCVERSION_ATTEMPT:
       return {

--- a/app/reducers/walletLoader.js
+++ b/app/reducers/walletLoader.js
@@ -45,7 +45,7 @@ import {
 } from "actions/WalletLoaderActions";
 import { GETSTARTUPWALLETINFO_ATTEMPT } from "actions/ClientActions";
 import { RESCAN_ATTEMPT } from "actions/ControlActions";
-import { WALLET_LOADER_SETTINGS } from "actions/DaemonActions";
+import { WALLET_LOADER_SETTINGS, QUIT_WALLET } from "actions/DaemonActions";
 
 export default function walletLoader(state = {}, action) {
   switch (action.type) {
@@ -337,6 +337,34 @@ export default function walletLoader(state = {}, action) {
       return {
         ...state,
         discoverAccountsComplete: action.discoverAccountsComplete
+      };
+    case QUIT_WALLET:
+      return {
+        ...state,
+        discoverAccountsComplete: null,
+        getLoaderError: null,
+        loader: null,
+        getLoaderRequestAttempt: false,
+        stepIndex: 0,
+        walletExistError: null,
+        walletExistRequestAttempt: false,
+        walletExistResponse: null,
+        walletOpenResponse: null,
+        advancedDaemonInputRequest: false,
+        startRpcRequestAttempt: false,
+        startRpcResponse: null,
+        startRpcError: null,
+        subscribeBlockNtfnsError: null,
+        subscribeBlockNtfnsRequestAttempt: false,
+        subscribeBlockNtfnsRequest: null,
+        subscribeBlockNtfnsResponse: null,
+        discoverAddressInputRequest: false,
+        discoverAddressError: null,
+        discoverAddressRequestAttempt: false,
+        discoverAddressResponse: null,
+        fetchHeadersRequestAttempt: false,
+        fetchHeadersResponse: null,
+        fetchHeadersError: null
       };
     default:
       return state;

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -996,3 +996,35 @@ export const stakeROIStats = createSelector(
 );
 
 export const modalVisible = get(["control", "modalVisible"]);
+
+export const hasUnresolvedRequests = createSelector(
+  getBalanceRequestAttempt,
+  getTransactionsRequestAttempt,
+  getTicketsRequestAttempt,
+  getNextAddressRequestAttempt,
+  constructTxRequestAttempt,
+  signTransactionRequestAttempt,
+  publishTransactionRequestAttempt,
+  purchaseTicketsRequestAttempt,
+  importScriptRequestAttempt,
+  getNextAccountRequestAttempt,
+  renameAccountRequestAttempt,
+  isOpeningWallet,
+  isSigningMessage,
+  isVerifyingMessage,
+  openWalletInputRequest,
+  createWalletInputRequest,
+  discoverAddressInputRequest,
+  selectCreateWalletInputRequest,
+  rescanRequest,
+  getTransactionsRequestAttempt,
+  getTicketsRequestAttempt,
+  validateAddressRequestAttempt,
+  currentStakePoolConfigRequest,
+  purchaseTicketsRequestAttempt,
+  shutdownRequested,
+  getMyTicketsStatsRequest,
+  exportingData,
+  loadingStartupStats,
+  (...args) => args.filter(Boolean).length > 0
+);

--- a/app/style/MiscComponents.less
+++ b/app/style/MiscComponents.less
@@ -535,6 +535,32 @@
   opacity: 0.7;
 }
 
+.quit-wallet-button {
+  outline: none;
+  background-color: transparent;
+  background-image: @launcher-current-wallet-deactivate;
+  background-size: 16px 16px;
+  background-repeat: no-repeat;
+  background-position: left;
+  cursor: pointer;
+  position: absolute;
+  margin-top: 10px;
+  padding: 10px 15px;
+  right: 30px;
+  color: #596d81;
+  opacity: 0.7;
+  border: 1px solid #fff;
+  border-radius: 5px;
+
+  span {
+    margin-left: 10px;
+  }
+
+  &:hover {
+    opacity: 1;
+  }
+}
+
 .context-menu-item {
   font-size: 13px;
   line-height: 2em;


### PR DESCRIPTION
This PR adds ability to go back to wallet selection after launching a wallet. Previously user was forced to close the whole app (not the greatest UX). 
The main issue here was resetting wallet specific state parts to initial values. Quit wallet button is disabled when user has unresolved, pending requests (quitting the wallet in this state would result in immediate crash).