### PR TITLE
Fetching available stakepools after wallet init

### DIFF
--- a/app/components/views/HomePage/index.js
+++ b/app/components/views/HomePage/index.js
@@ -12,6 +12,10 @@ class Home extends React.Component {
     this.state = this.getInitialState();
   }
 
+  componentDidMount() {
+    this.props.discoverAvailableStakepools();
+  }
+
   getInitialState() {
     return {
       onCancelPassphraseRequest: null,

--- a/app/components/views/TicketsPage/PurchaseTab/StakePools/List.js
+++ b/app/components/views/TicketsPage/PurchaseTab/StakePools/List.js
@@ -15,7 +15,7 @@ const StakePoolsList = ({
     <div className="stakepool-flex-height">
       <div className="stakepool-content-nest-from-address">
         <div className="stakepool-content-nest-prefix-configured">
-          <T id="stakepools.list.title" m="Configured stake pools:" />
+          <T id="stakepools.list.title" m="Configured stake pools" />
         </div>
       </div>
       <div id="dynamicInput">
@@ -71,16 +71,16 @@ const StakePoolsList = ({
       </div>
     </div>
     {unconfiguredStakePools.length > 0 ? (
-      <KeyBlueButton
+      <SlateGrayButton
         className="stakepool-content-send"
         disabled={rescanRequest}
         onClick={onShowAddStakePool}>
-        <T id="stakepools.list.form.submit" m="Add stakepool" />
-      </KeyBlueButton>
+        <T id="stakepools.list.form.submit" m="Add another stakepool" />
+      </SlateGrayButton>
     ) : null}
-    <SlateGrayButton className="stakepool-hide-config" onClick={onHideStakePoolConfig}>
-      <T id="stakepools.list.form.cancel" m="Cancel" />
-    </SlateGrayButton>
+    <KeyBlueButton className="stakepool-hide-config" onClick={onHideStakePoolConfig}>
+      <T id="stakepools.list.form.cancel" m="Go to ticket purchase" />
+    </KeyBlueButton>
   </Aux>
 );
 

--- a/app/connectors/home.js
+++ b/app/connectors/home.js
@@ -4,6 +4,7 @@ import { selectorMap } from "fp";
 import * as selectors from "selectors";
 import * as controlActions from "actions/ControlActions";
 import * as clientActions from "actions/ClientActions";
+import * as stakepoolActions from "actions/StakePoolActions";
 
 const mapStateToProps = selectorMap({
   getTransactionsRequestAttempt: selectors.getTransactionsRequestAttempt,
@@ -25,7 +26,8 @@ const mapDispatchToProps = dispatch =>
       onClearRevokeTicketsError: controlActions.clearRevokeTicketsError,
       onClearRevokeTicketsSuccess: controlActions.clearRevokeTicketsSuccess,
       goToMyTickets: clientActions.goToMyTickets,
-      goToTransactionHistory: clientActions.goToTransactionHistory
+      goToTransactionHistory: clientActions.goToTransactionHistory,
+      discoverAvailableStakepools: stakepoolActions.discoverAvailableStakepools
     },
     dispatch
   );

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -263,13 +263,6 @@ export const transactionNormalizer = createSelector(
           totalFundsReceived += amount;
         }
       });
-      console.log(
-        txInfo.height,
-        "totalFundsReceived",
-        totalFundsReceived,
-        "totalChange",
-        totalChange
-      );
       const txDetails =
         totalFundsReceived + totalChange + fee < totalDebit
           ? {


### PR DESCRIPTION
We want to fetch stakepools addresses and update available (unconfigured) stakepools data, so that user always has data in sync. Additionally, there is slight change in UI to make it less confusing.